### PR TITLE
Fix split tags type and fix nil pointer deference in checkRateLimit

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -140,7 +140,7 @@ func (c *Client) setHeaders() {
 }
 
 func (c *Client) checkRateLimit(resp *simpleresty.Response) bool {
-	if resp.StatusCode == 429 {
+	if resp != nil && resp.StatusCode == 429 {
 		remainingOrgSeconds, _ := strconv.Atoi((resp.Resp.Header().Get("X-RateLimit-Reset-Seconds-Org")))
 		timeToSleep, _ := strconv.Atoi(resp.Resp.Header().Get("X-RateLimit-Reset-Seconds-IP"))
 		if remainingOrgSeconds != 0 {

--- a/api/split.go
+++ b/api/split.go
@@ -18,7 +18,7 @@ type Split struct {
 	ID                     *string             `json:"id"`
 	Name                   *string             `json:"name"`
 	Description            *string             `json:"description"`
-	Tags                   []string            `json:"tags,omitempty"`
+	Tags                   []SplitTag          `json:"tags,omitempty"`
 	CreationTime           *int64              `json:"creationTime"`
 	RolloutStatusTimestamp *int64              `json:"rolloutStatusTimestamp"`
 	TrafficType            *TrafficType        `json:"trafficType"`
@@ -46,6 +46,11 @@ type SplitCreateRequest struct {
 // SplitUpdateRequest represents a request to update a split.
 type SplitUpdateRequest struct {
 	Description string `json:"description"`
+}
+
+// SplitTag represents a tag in the split
+type SplitTag struct {
+	Name string `json:"name"`
 }
 
 // List all splits.


### PR DESCRIPTION
This PR is to fix 
https://github.com/davidji99/terraform-provider-split/issues/114
Based on API calls to split, it doesn't return a list of strings in tags, it's a key/value.

```bash
> curl -X GET \
  -H 'Content-Type:application/json' \
  -H 'Authorization: Bearer <redacted>' \
  https://api.split.io/internal/api/v2/splits/ws/<redacted>/<redacted>/
{"id":"<redacted>","name":"<redacted>","description":"<redacted>","trafficType":{"id":"<redacted>","name":"user"},"creationTime":1583520739006,"tags":[{"name":"<redacted>"},{"name":"<redacted>"}],"owners":[{"id":"<redacted>","type":"user"},{"id":"<redacted>","type":"group"}]}
```

I also fixed a nil pointer deference that I introduced in #111