### PR TITLE
Allow MATCHES_STRING for single string

### DIFF
--- a/split/import_split_split_definition_test.go
+++ b/split/import_split_split_definition_test.go
@@ -2,10 +2,11 @@ package split
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 )
 
 func TestAccSplitSplitDefinition_importBasic(t *testing.T) {
@@ -22,7 +23,7 @@ func TestAccSplitSplitDefinition_importBasic(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckSplitSplitDefinition_basicUpdated(workspaceID, trafficTypeName, splitName,
+				Config: testAccCheckSplitSplitDefinition_multipleMatchers(workspaceID, trafficTypeName, splitName,
 					"my split description", envID, trafficTypeID),
 			},
 			{

--- a/split/resource_split_split_definition.go
+++ b/split/resource_split_split_definition.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+
 	"github.com/davidji99/terraform-provider-split/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
 )
 
 var (
@@ -163,12 +164,17 @@ func resourceSplitSplitDefinition() *schema.Resource {
 													Required: true,
 												},
 
+												"string": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+
 												"strings": {
 													Type: schema.TypeList,
 													Elem: &schema.Schema{
 														Type: schema.TypeString,
 													},
-													Required: true,
+													Optional: true,
 												},
 											},
 										},
@@ -494,6 +500,9 @@ func constructSplitDefinitionRequestOpts(d *schema.ResourceData) (*api.SplitDefi
 							if v, ok := matcher["attribute"].(string); ok {
 								newRuleConditionMatcher.Attribute = &v
 							}
+							if v, ok := matcher["string"].(string); ok {
+								newRuleConditionMatcher.String = &v
+							}
 							if v, ok := matcher["strings"]; ok {
 								stringsRaw := v.([]interface{})
 								sList := make([]string, 0)
@@ -571,6 +580,7 @@ func setRuleInState(d *schema.ResourceData, sd *api.SplitDefinition) {
 			ruleConditionMatchers = append(ruleConditionMatchers, map[string]interface{}{
 				"type":      rcm.GetType(),
 				"attribute": rcm.GetAttribute(),
+				"string":    rcm.GetString(),
 				"strings":   rcm.Strings,
 			})
 		}


### PR DESCRIPTION
See: https://docs.split.io/reference/matcher-type#matches_string

The `string` (missing attribute) or `strings` depends on the matcher type.