### PR TITLE
feat: make attribute optional

### DIFF
--- a/split/resource_split_split_definition.go
+++ b/split/resource_split_split_definition.go
@@ -161,7 +161,7 @@ func resourceSplitSplitDefinition() *schema.Resource {
 
 												"attribute": {
 													Type:     schema.TypeString,
-													Required: true,
+													Optional: true,
 												},
 
 												"string": {


### PR DESCRIPTION
- It depends on the type of the operation
- For instance, for IN_LIST_STRING, it can be null to make the decision based on the key and not an attribute
- https://docs.split.io/reference/matcher-type#in_list_string