### PR TITLE
feat: send title for changes

### DIFF
--- a/api/split_definition.go
+++ b/api/split_definition.go
@@ -35,6 +35,7 @@ type SplitDefinitionRequest struct {
 	DefaultRule       []Bucket    `json:"defaultRule"`
 	DefaultTreatment  string      `json:"defaultTreatment"`
 	Comment           string      `json:"comment,omitempty"`
+	Title             string      `json:"title,omitempty"`
 	TrafficAllocation int         `json:"trafficAllocation"`
 }
 

--- a/split/resource_split_split_definition.go
+++ b/split/resource_split_split_definition.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+
 	"github.com/davidji99/terraform-provider-split/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
 )
 
 var (
@@ -360,6 +361,8 @@ func resourceSplitSplitDefinitionDelete(ctx context.Context, d *schema.ResourceD
 
 func constructSplitDefinitionRequestOpts(d *schema.ResourceData) (*api.SplitDefinitionRequest, error) {
 	opts := &api.SplitDefinitionRequest{}
+
+	opts.Title = "terraform-provider-split"
 
 	if v, ok := d.GetOk("default_treatment"); ok {
 		opts.DefaultTreatment = v.(string)


### PR DESCRIPTION
Historically, the Terraform provider has been sending `null` strings in the `title` field for split changes in the different APIs, since Terraform changes are not initiated by the user in the web UI but rather due to a configuration change (and it doesn't make sense to put the field in the resource definition in Terraform since it would change on each apply).

The problem is that Split allows configuring mandatory title for changes, which then breaks IaC changes on the API:


```hcl
running "/usr/local/bin/terraform apply ...": exit status 1
module.this...: Modifying... [id=...]
╷
│ Error: Unable to update split definition ...
│ 
│   with module.this...
│   on ../../../modules/split/main.tf line 9, in resource "split_split_definition" "this":
│    9: resource "split_split_definition" "this" {
│ 
│ PUT
│ https://api.split.io/internal/api/v2/splits/ws/<UUID>/<SPLIT_NAME>/environments/<UUID>:
│ 400 {"code":400,"message":"Comment/title combination invalid for
│ workspace","details":"","transactionId":"..."}
```

This change addresses that issue via sending a default title with the provider name. This is how ends up looking in webUI:

![image](https://github.com/user-attachments/assets/7c9264a1-00d3-4842-89a0-4e2299fdc467)

Thank you @davidji99 for reviewing and let me know if there are any remarks. Cheers