### PR TITLE
Change api key name length limit

### DIFF
--- a/split/resource_split_api_key.go
+++ b/split/resource_split_api_key.go
@@ -43,7 +43,7 @@ func resourceSplitApiKey() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 15),
+				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 
 			"type": {


### PR DESCRIPTION
SDK API key has limit of 100 characters, not 15:

<img width="976" alt="Screenshot 2025-07-08 at 12 56 27 PM" src="https://github.com/user-attachments/assets/0486f8d9-24bd-47bf-8a87-fbe5deebe9a2" />
